### PR TITLE
Add of the views for login user, sign up & forgot password

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,26 @@
-<h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="card col-4">
+  <div class="card-body p-4 p-sm-5">
+  <div class="row flex-between-center mb-2">
+  <div class="col-auto"><h5>Olvidaste tu contraseña?</h5></div>
+    <section data-dashlane-rid="fa3f30e7db01eedc" data-form-type="sing up">
+        <p class="col-auto">*Por favor llena los campos correspondientes<br>
+        </p>
+        <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+            <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="mb-3"><br>
+          <%= f.label :email, "Ingresa tu correo electronico" ,class:"col-auto" %><br />
+             <%= f.email_field :email, autofocus: true, autocomplete: "correo electronico", class:"form-control" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "Enviarme las instrucciones para cambiar mi contraseña", class:"btn btn-primary d-block w-100 mt-3" %>
+        </div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+        <%= link_to "Iniciar sesion", user_session_path, method: :get, class:"col-auto fs--1 text-600 mb-0 undefined" %>
+        <p>ó</p>
+        <%= link_to "Registrarse", new_user_registration_path, method: :get, class:"col-auto fs--1 text-600 mb-0 undefined" %>
+    </section>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+    </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,34 @@
-<h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="card col-4">
+  <div class="card-body p-4 p-sm-5">
+  <div class="row flex-between-center mb-2">
+  <div class="col-auto"><h5>Registrar Usuario</h5></div>
+    <section data-dashlane-rid="fa3f30e7db01eedc" data-form-type="sing up">
+        <p class="col-auto">*Por favor llena los campos correspondientes<br>
+        </p>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <div class="mb-3"><br>
+          <%= f.label :email, "Correo electronico", class:"col-auto" %><br />
+             <%= f.email_field :email, autofocus: true, autocomplete: "correo electronico", class:"form-control" %>
+        </div>
+        <div class="mb-3"><br>
+              <%= f.label :password, "Contraseña", class:"col-auto" %>
+              <% if @minimum_password_length %>
+              <em>(Ingrese minimo <%= @minimum_password_length %> caracteres)</em>
+              <% end %><br />
+              <%= f.password_field :password, autocomplete: "contraseña actual", class:"form-control" %>
+        </div>
+        <div class="mb-3"><br>
+          <%= f.label :password_confirmation, "Confirmar contraseña", class:"col-auto" %><br />
+            <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %>
+        </div>
+        <div class="actions">
+              <%= f.submit "Registrar", class:"btn btn-primary d-block w-100 mt-3" %>
+        </div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+        <%= link_to "Iniciar sesion", user_session_path, method: :get, class:"col-auto fs--1 text-600 mb-0 undefined" %>
+    </section>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+    </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,32 +1,35 @@
-<body class="backgroud">
-  <div class="box1">
-    <section class="box2">
-        <%= image_tag 'serenity_logo_negro.png', class:"logo"%>
-        <p class="description">*Please fill in your unique admin login details below<br>
+
+<div class="card col-4">
+  <div class="card-body p-4 p-sm-5">
+  <div class="row flex-between-center mb-2">
+  <div class="col-auto"><h5>Iniciar sesion</h5></div>
+  <div class="col-auto fs--1 text-600"><span class="mb-0 undefined">o</span> <%= link_to "Registrarse", new_user_registration_path, method: :get, class:"col-auto fs--1 text-600 mb-0 undefined" %></div>
+    <section data-dashlane-rid="fa3f30e7db01eedc" data-form-type="login">
+        <p class="col-auto">*Ingresa tu correo electronico y contraseña para acceder como administrador<br>
         </p>
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <div class="field mail"><br>
-          <%= f.label :email, "Email address", class:"label_devise" %><br />
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"input_devise" %>
+        <div class="mb-3"><br>
+          <%= f.label :email, "Correo Electronico", class:"col-auto" %><br />
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control" %>
         </div>
-        <div class="field pass"><br>
-          <%= f.label :password, "Password", class:"label_devise" %><br />
-            <%= f.password_field :password, autocomplete: "current-password", class:"input_devise" %>
+        <div class="mb-3"><br>
+          <%= f.label :password, "Contraseña", class:"col-auto" %><br />
+            <%= f.password_field :password, autocomplete: "current-password", class:"form-control" %>
         </div>
         <% if devise_mapping.rememberable? %>
-        <div class="field remember">
+        <div class="form-check mb-0">
           <%= f.check_box :remember_me %>
-              <%= f.label :remember_me %>
+              <%= f.label :remember_me, "Recordar usuario" %>
         </div>
         <% end %>
-          <div class="link_s"><br>
-              <%= render "devise/shared/links" %>
-            </div>
-          <div class="login"><br>
-            <%= f.submit "Sign in", class:"button_login" %>
+          <div class="mb-3"><br>
+            <%= f.submit "Iniciar Sesion", class:"btn btn-primary d-block w-100 mt-3" %>
           </div>
         <% end %>
+        </div>
+          <%= link_to "Olvido su contraseña?", new_user_password_path, method: :get, class:"col-auto fs--1 text-600 mb-0 undefined" %>
+        </div>
     </section>
 
     </div>
-</body>
+</div>


### PR DESCRIPTION
I've added the views for login user, sign up, and forgot password. Fully functional and adapted to the agreed design.
  
  ## Screenshots 

[Log in Desktop]
![log_in](https://user-images.githubusercontent.com/93165352/179856480-f031924e-cd85-4519-9b6c-94f33945a0ba.png)

[Sign Up Desktop]
![sign_up](https://user-images.githubusercontent.com/93165352/179856489-4dc0c833-9529-469a-8070-647b7cd1c952.png)

[Forgot Password Desktop]
![forgot_password](https://user-images.githubusercontent.com/93165352/179856499-d5c3ef74-bc16-4730-844a-ede045715ba1.png)

